### PR TITLE
Add atlas-app-toolkit to the gentool

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -38,3 +38,7 @@ import:
   # gorm code generator
   - package: github.com/infobloxopen/protoc-gen-gorm
     version: v0.1.0
+    
+  # atlas app toolkit
+  - package: github.com/infobloxopen/atlas-app-toolkit
+    version: v0.2.0


### PR DESCRIPTION
This pull request adds the Atlas application toolkit to the list of gentool repositories, which will make the `op/collection_operators.proto` file accessable.