### PR TITLE
Add atlas-app-toolkit to the list of gentool packages

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -38,3 +38,7 @@ import:
   # gorm code generator
   - package: github.com/infobloxopen/protoc-gen-gorm
     version: v0.2.0
+  
+  # atlas application toolkit
+  - package: github.com/infobloxopen/atlas-app-toolkit
+    version: v0.3.0


### PR DESCRIPTION
# Add atlas-app-toolkit to gentool

This is a duplicate of #2. As it turns out, we do need the `atlas-app-toolkit` to be included in the list of packages included inthe gentool image.

I'll give an example that doesn't work without having the toolkit included in the gentool image.

```proto
import "github.com/infobloxopen/atlas-app-toolkit/op/collection_operators.proto";

... 

message Response {
    infoblox.api.PageInfo page = 1;
    repeated Person result = 2;
}
```
The only reason the pre-infobloxopen example worked (i.e. the internal address book example) is because the entire toolkit was copied into the gentool container (along with the collection `collection_operators.proto` file). In other words, the application _and_ the toolkit were in the same repository, which is why this issue came up after we split the toolkit and the contacts application into separate projects. 

