### PR TITLE
Fix field_mask and add protoc-gen-swagger with atlas-patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,8 @@ WORKDIR /go/src
 RUN mkdir -p google/protobuf && \
   for f in any duration empty struct timestamp wrappers; do \
     cp /go/src/github.com/golang/protobuf/ptypes/${f}/${f}.proto /go/src/google/protobuf; \
-  done
+  done; \
+  cp /go/src/github.com/google/protobuf/src/google/protobuf/field_mask.proto /go/src/google/protobuf;
 
 # protoc as an entry point for all plugins with import paths set
 ENTRYPOINT ["protoc", "-I.", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,12 +50,15 @@ RUN curl -fsSL ${GLIDE_DOWNLOAD_URL} -o glide.tar.gz \
 # Install as the protoc plugins as build-time dependecies.
 COPY glide.yaml.tmpl .
 
+# glide is unable to resolve correctly these deps requiring
+# to import all the dependencies in go-openapi/spec and ghodss/yaml
+RUN go get github.com/go-openapi/spec; \ 
+    go get github.com/ghodss/yaml;
+
 # Compile binaries for the protocol buffer plugins. We need specific
 # versions of these tools, this is why we at first step install glide,
 # download required versions and then installing them.
-RUN go get github.com/go-openapi/spec; \
-    go get github.com/ghodss/yaml; \
-    sed -e "s/@PGGVersion/$PGG_VERSION/" -e "s/@AATVersion/$AATVersion/" glide.yaml.tmpl > glide.yaml; \
+RUN sed -e "s/@PGGVersion/$PGG_VERSION/" -e "s/@AATVersion/$AATVersion/" glide.yaml.tmpl > glide.yaml; \
     glide up --skip-test \
     && cp -r vendor/* ${GOPATH}/src/ \
     && go install github.com/golang/protobuf/protoc-gen-go \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,9 @@ COPY glide.yaml.tmpl .
 # Compile binaries for the protocol buffer plugins. We need specific
 # versions of these tools, this is why we at first step install glide,
 # download required versions and then installing them.
-RUN sed -e "s/@PGGVersion/$PGG_VERSION/" -e "s/@AATVersion/$AATVersion/" glide.yaml.tmpl > glide.yaml; \
+RUN go get github.com/go-openapi/spec; \
+    go get github.com/ghodss/yaml; \
+    sed -e "s/@PGGVersion/$PGG_VERSION/" -e "s/@AATVersion/$AATVersion/" glide.yaml.tmpl > glide.yaml; \
     glide up --skip-test \
     && cp -r vendor/* ${GOPATH}/src/ \
     && go install github.com/golang/protobuf/protoc-gen-go \

--- a/README.md
+++ b/README.md
@@ -41,9 +41,37 @@ docker run --rm -v $(pwd):/go/src/${project} \
 - protoc-gen-gogoslick
 - protoc-gen-gogotypes
 - protoc-gen-gostring
-- protoc-gen-swagger
+- protoc-gen-swagger (**atlas-patch**)
 - protoc-gen-grpc-gateway
 - protoc-gen-validate
 - protoc-gen-govalidators
 - protoc-gen-doc
 - protoc-gen-gorm (**Infoblox Open**)
+
+## protoc-gen-swagger patch
+
+protoc-gen-swagger patch includes following changes:
+
+ * Fixed method comments extraction
+
+ * Rendering of messages that have a primitive type (STRING, INT, BOOLEAN)
+   does not occur if message is used only as a field (not an rpc Request or Response),
+   hence recursive message definitions and complex-structured messages can be presented
+   as plain string query parameters.
+
+ * Introduced new `atlas_patch` flag. If this flag is enabled `--swagger_out="atlas_patch=true:."`
+   following changes are made to a swagger spec:
+
+   * All responses are wrapped with `success` field and assigned to an appropriate response code:
+     GET - 200/OK, POST - 201/CREATED, PUT - 202/UPDATED, DELETE - 203/DELETED.
+
+   * Recursive references are broken up. Such references occur while using protoc-gen-gorm plugin
+     with many-to-many/one-to-many relations.
+
+   * Collection operators from atlas-app-toolkit are provided with documentation and correct
+     names.
+
+   * atlas.rpc.identifier in path is treated correctly and not distributed among path and
+     query parameters, also id.payload_id is replaced with id in path.
+
+   * Unused references elimination.

--- a/README.md
+++ b/README.md
@@ -50,28 +50,6 @@ docker run --rm -v $(pwd):/go/src/${project} \
 
 ## protoc-gen-swagger patch
 
-protoc-gen-swagger patch includes following changes:
-
- * Fixed method comments extraction
-
- * Rendering of messages that have a primitive type (STRING, INT, BOOLEAN)
-   does not occur if message is used only as a field (not an rpc Request or Response),
-   hence recursive message definitions and complex-structured messages can be presented
-   as plain string query parameters.
-
- * Introduced new `atlas_patch` flag. If this flag is enabled `--swagger_out="atlas_patch=true:."`
-   following changes are made to a swagger spec:
-
-   * All responses are wrapped with `success` field and assigned to an appropriate response code:
-     GET - 200/OK, POST - 201/CREATED, PUT - 202/UPDATED, DELETE - 203/DELETED.
-
-   * Recursive references are broken up. Such references occur while using protoc-gen-gorm plugin
-     with many-to-many/one-to-many relations.
-
-   * Collection operators from atlas-app-toolkit are provided with documentation and correct
-     names.
-
-   * atlas.rpc.identifier in path is treated correctly and not distributed among path and
-     query parameters, also id.payload_id is replaced with id in path.
-
-   * Unused references elimination.
+atlas-patch is build on top of original protoc-gen-swagger and is intended to
+conform [atlas-app-toolkit REST API Sepcification](https://github.com/infobloxopen/atlas-app-toolkit#rest-api-syntax-specification).
+A full list of modifications can be found [here](https://github.com/infobloxopen/grpc-gateway/tree/atlas-patch/protoc-gen-swagger)

--- a/glide.yaml.tmpl
+++ b/glide.yaml.tmpl
@@ -1,16 +1,19 @@
 import:
   # standard proto code generator
   - package: github.com/golang/protobuf
-    #version: v1.0.0
+    version: v1.0.0
 
   # alternative proto code generator
   - package: github.com/gogo/protobuf
-    #version: v1.0.0
+    version: v1.0.0
+
+  # field_mask source
+  - package: github.com/google/protobuf
 
   # HTTP-gRPC reverse-proxy code generator
   - package: github.com/grpc-ecosystem/grpc-gateway
     repo:    https://github.com/infobloxopen/grpc-gateway.git
-    #version: v1.3.1
+    version: atlas-patch
 
   # grpc-gateway dependency
   - package: github.com/golang/glog

--- a/glide.yaml.tmpl
+++ b/glide.yaml.tmpl
@@ -1,15 +1,16 @@
 import:
   # standard proto code generator
   - package: github.com/golang/protobuf
-    version: v1.0.0
+    #version: v1.0.0
 
   # alternative proto code generator
   - package: github.com/gogo/protobuf
-    version: v1.0.0
+    #version: v1.0.0
 
   # HTTP-gRPC reverse-proxy code generator
   - package: github.com/grpc-ecosystem/grpc-gateway
-    version: v1.3.1
+    repo:    https://github.com/infobloxopen/grpc-gateway.git
+    #version: v1.3.1
 
   # grpc-gateway dependency
   - package: github.com/golang/glog

--- a/glide.yaml.tmpl
+++ b/glide.yaml.tmpl
@@ -12,8 +12,7 @@ import:
 
   # HTTP-gRPC reverse-proxy code generator
   - package: github.com/grpc-ecosystem/grpc-gateway
-    repo:    https://github.com/infobloxopen/grpc-gateway.git
-    version: atlas-patch
+    version: v1.4.1
 
   # grpc-gateway dependency
   - package: github.com/golang/glog


### PR DESCRIPTION
field_mask patch resolves error with invalid 'google/protobuf' import.

atlas-patch includes following changes:

  * fix proto comment extraction for files with multiple services
  * fix recursion issues with filtering

in addition, setting atlas_patch=true enables following features:

  * break recursive refs introduced by many to many
  * wrap responses with success
  * add filtering, sorting, field_selection and paging documentation
  * fix atlas.rpc.Identifier path/query parameter
  * cleanup unused refs.