### PR TITLE
Add protoc-gen-atlas-validate plugin to gentool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,10 +83,11 @@ RUN go install  \
       github.com/infobloxopen/protoc-gen-gorm
 
 # Download all dependencies of protoc-gen-atlas-query-perm
-RUN cd ${GOPATH}/src/github.com/infobloxopen/protoc-gen-atlas-query-perm && \
-    dep ensure -vendor-only
-
+RUN cd ${GOPATH}/src/github.com/infobloxopen/protoc-gen-atlas-query-perm && dep ensure -vendor-only
 RUN go install github.com/infobloxopen/protoc-gen-atlas-query-perm
+
+RUN cd ${GOPATH}/src/github.com/infobloxopen/protoc-gen-atlas-validate && dep ensure -vendor-only
+RUN go install github.com/infobloxopen/protoc-gen-atlas-validate
 
 RUN rm -rf vendor/* ${GOPATH}/pkg/* \
     && install -c ${GOPATH}/bin/protoc-gen* /out/usr/bin/
@@ -143,5 +144,7 @@ ENTRYPOINT ["protoc", "-I.", \
     # required import paths for protoc-gen-gorm plugin
     "-Igithub.com/infobloxopen/protoc-gen-gorm", \
     # required import paths for protoc-gen-perm plugin
-    "-Igithub.com/infobloxopen/protoc-gen-atlas-query-perm" \
+    "-Igithub.com/infobloxopen/protoc-gen-atlas-query-perm", \
+    # required import paths for protoc-gen-perm plugin
+    "-Igithub.com/infobloxopen/protoc-gen-atlas-validate" \
 ]

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ test-gen:
 	--validate_out="lang=go:." \
 	--gorm_out=. \
 	--atlas-query-perm_out=. \
+	--atlas-validate_out=. \
 	--swagger_out=:. github.com/infobloxopen/atlas-gentool/testdata/test.proto
 
 test-check:

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test-check:
 	test -e testdata/test.pb.gw.go
 	test -e testdata/test.pb.gorm.go
 	test -e testdata/test.pb.perm.go
+	test -e testdata/test.pb.atlas.validate.go
 	test -e testdata/test.pb.validate.go
 	test -e testdata/test.swagger.json
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ docker run --rm -v $(pwd):/go/src/${project} \
 - protoc-gen-doc
 - protoc-gen-gorm (**Infoblox Open**)
 - protoc-gen-atlas-query-perm (**Infoblox Open**)
+- protoc-gen-atlas-validate (**Infoblox Open**)
 
 ## protoc-gen-swagger patch
 

--- a/glide.yaml.tmpl
+++ b/glide.yaml.tmpl
@@ -49,6 +49,9 @@ import:
   # atlas query permission validaton generator
   - package: github.com/infobloxopen/protoc-gen-atlas-query-perm
 
+  # atlas validaton generator
+  - package: github.com/infobloxopen/protoc-gen-atlas-validate
+
   - package: github.com/jinzhu/gorm
     version: v1.9.1
 

--- a/testdata/test.proto
+++ b/testdata/test.proto
@@ -7,6 +7,7 @@ import "github.com/lyft/protoc-gen-validate/validate/validate.proto";
 import "protoc-gen-swagger/options/annotations.proto";
 import "github.com/infobloxopen/protoc-gen-gorm/options/gorm.proto";
 import "github.com/infobloxopen/protoc-gen-atlas-query-perm/options/collection_permissions.proto";
+import "github.com/infobloxopen/protoc-gen-atlas-validate/options/atlas_validate.proto";
 
 message Example {
   option (gorm.opts).ormable = true;
@@ -16,11 +17,27 @@ message Example {
 
 service ExampleService {
     rpc Something (Example) returns (Example) {
+        option (atlas_validate.method).allow_unknown_fields = true;
         option (google.api.http) = {
             get: "/example"
         };
     }
+
+    rpc Create (Example) returns (Example) {
+        option (atlas_validate.method).allow_unknown_fields = false;
+        option (google.api.http) = {
+            post: "/example"
+        };
+    }
+
+    rpc Test (Example) returns (Example) {
+        option (google.api.http) = {
+            post: "/test"
+        };
+    }
 }
+
+option (atlas_validate.file).allow_unknown_fields = false;
 
 option (grpc.gateway.protoc_gen_swagger.options.openapiv2_swagger) = {
   info: {


### PR DESCRIPTION
Unable to test it as `make latest` fails at the moment in master. Need to fix this first.