### PR TITLE
Lock version of atlas-gen-validate to new version with maps fix

### DIFF
--- a/glide.yaml.tmpl
+++ b/glide.yaml.tmpl
@@ -51,7 +51,7 @@ import:
 
   # atlas validaton generator
   - package: github.com/infobloxopen/protoc-gen-atlas-validate
-    version: 9c77857916f43a2167aff8cd455b7ac58cdc9454
+    version: v0.1.2
 
   # preprocessing generator
   - package: github.com/infobloxopen/protoc-gen-preprocess

--- a/glide.yaml.tmpl
+++ b/glide.yaml.tmpl
@@ -51,6 +51,7 @@ import:
 
   # atlas validaton generator
   - package: github.com/infobloxopen/protoc-gen-atlas-validate
+    version: 9c77857916f43a2167aff8cd455b7ac58cdc9454
 
   # preprocessing generator
   - package: github.com/infobloxopen/protoc-gen-preprocess


### PR DESCRIPTION
Locking the version of protoc-gen-atlas-validate so that builds are more reproducible, and updating it to include the fix in https://github.com/infobloxopen/protoc-gen-atlas-validate/pull/4