### PR TITLE
Update protoc-gen-grpc-gateway

### DIFF
--- a/glide.yaml.tmpl
+++ b/glide.yaml.tmpl
@@ -1,7 +1,7 @@
 import:
   # standard proto code generator
   - package: github.com/golang/protobuf
-    version: v1.0.0
+    version: v1.3.1
 
   # alternative proto code generator
   - package: github.com/gogo/protobuf
@@ -12,19 +12,19 @@ import:
 
   # HTTP-gRPC reverse-proxy code generator
   - package: github.com/grpc-ecosystem/grpc-gateway
-    version: v1.4.1
+    version: v1.9.6
 
   # grpc-gateway dependency
   - package: github.com/golang/glog
     version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 
-  # generated googleapis proto files
+  # generated googleapis proto files (related to grpc-gateway v1.9.6)
   - package: google.golang.org/genproto
-    version: 2b5a72b8730b0b16380010cfe5286c42108d88e7
+    version: c66870c02cf823ceb633bcd05be3c7cda29976f4
 
-  # googleapis proto files
+  # googleapis proto files (Aug 30, 2019)
   - package: github.com/googleapis/googleapis
-    version: 79d2054a2380a3567d2c8bd57735155370c39840
+    version: 82809578652607c8ee29d9e199c21f28f81a03e0
 
   # proto2: validation code generator
   - package: github.com/lyft/protoc-gen-validate


### PR DESCRIPTION
Update github.com/grpc-ecosystem/grpc-gateway to v1.9.6 + update related plugins (including github.com/golang/protobuf update to v1.3.1)

Connected with a request in issue #43 