### PR TITLE
fix versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ IMAGE_NAME := infoblox/atlas-gentool
 GO_PATH              	:= /go
 SRCROOT_ON_HOST      	:= $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 SRCROOT_IN_CONTAINER  := $(GO_PATH)/src/github.com/infobloxopen/atlas-gentool
-IMAGE_VERSION	        ?= $(shell git tag --points-at HEAD | sort -n -r | head -1)
+IMAGE_VERSION	        ?= $(shell git describe --tags)
 
 get_version = sed -n 's/^$(1)=//p' plugin.version
 


### PR DESCRIPTION
The old version string generator only worked on tags. Now we can build versions like `infoblox/atlas-gentool:v21.3-4-g853297a` between tags. The existing behavior on tags is unchanged.