### PR TITLE
Version envoyproxy/protoc-gen-validate via glide.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ARG PGP_VERSION=master
 
 # Set up mandatory Go environmental variables.
 ENV CGO_ENABLED=0
+ENV GO111MODULE=off
 
 RUN apk update \
     && apk add --no-cache --purge git curl upx
@@ -61,7 +62,7 @@ RUN go install github.com/gogo/protobuf/protoc-gen-gostring
 RUN go get github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema
 RUN go install github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema
 RUN go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
-RUN go get github.com/envoyproxy/protoc-gen-validate
+RUN go install github.com/envoyproxy/protoc-gen-validate
 RUN go install github.com/mwitkow/go-proto-validators/protoc-gen-govalidators
 RUN go install github.com/pseudomuto/protoc-gen-doc/cmd/...
 RUN go install github.com/infobloxopen/protoc-gen-preprocess

--- a/glide.yaml.tmpl
+++ b/glide.yaml.tmpl
@@ -26,9 +26,9 @@ import:
   - package: github.com/googleapis/googleapis
     version: 82809578652607c8ee29d9e199c21f28f81a03e0
 
-  # proto2: validation code generator
-  - package: github.com/lyft/protoc-gen-validate
-    version: v0.0.7
+  # validation code generator
+  - package: github.com/envoyproxy/protoc-gen-validate
+    version: v0.1.0
 
   # proto3: validation code generator
   - package: github.com/mwitkow/go-proto-validators

--- a/testdata/test.proto
+++ b/testdata/test.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package test;
 
 import "google/api/annotations.proto";
-import "github.com/lyft/protoc-gen-validate/validate/validate.proto";
+import "github.com/envoyproxy/protoc-gen-validate/validate/validate.proto";
 import "protoc-gen-swagger/options/annotations.proto";
 import "github.com/infobloxopen/protoc-gen-gorm/options/gorm.proto";
 import "github.com/infobloxopen/protoc-gen-atlas-query-validate/options/query_validate.proto";


### PR DESCRIPTION
github.com/**envoyproxy**/protoc-gen-validate dependency is fetched with `go get` command every time **atlas-gentool** is built. Also there is still github.com/**lyft**/protoc-gen-validate dependency that should not be there. 

This causes problems because dependencies are intermixed. Basically, here we have lyft/protoc-gen-validate of certain version (v0.0.7) in atlas-gentool managed by deprecated glide dependency tool. It gets pulled with all its dependencies but then go get command fetches the latest version of  **envoyproxy**/protoc-gen-validate without updating dependencies  brought in by **lyft**/protoc-gen-validate.  

Fetching a fresh version of protoc-gen-validate every time is very unsafe as owners of the repo claim themselves: 

> This project is currently in alpha. The API should be considered unstable and likely to change

The PR makes sure that v0.1.0 of github.com/envoyproxy/protoc-gen-validate package is used all the time. 

Make sure proto file has proper import declaration (lyft -> envoyproxy) when using this tool: 
```
- import "github.com/lyft/protoc-gen-validate/validate/validate.proto";
+ import "github.com/envoyproxy/protoc-gen-validate/validate/validate.proto";
```

