### PR TITLE
Upgrade infobloxopen/grpc-gateway to v2.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN rm -rf vendor/* ${GOPATH}/pkg/* \
 
 # Build protoc-gen-grpc-gateway and protoc-gen-openapiv2 from infobloxopen/grpc-gateway where it is kept consistent
 # with infoblox products (protoc-gen-openapiv2 atlas_patch, etc.).
-RUN cd ${GOPATH}/src/github.com/infobloxopen && git clone --single-branch --branch v2.0.1 https://github.com/infobloxopen/grpc-gateway.git && \
+RUN cd ${GOPATH}/src/github.com/infobloxopen && git clone --single-branch --branch v2.0.2 https://github.com/infobloxopen/grpc-gateway.git && \
     cd ${GOPATH}/src/github.com/infobloxopen/grpc-gateway/protoc-gen-grpc-gateway && go build -o /out/usr/bin/protoc-gen-grpc-gateway main.go && \
     cd ${GOPATH}/src/github.com/infobloxopen/grpc-gateway/protoc-gen-openapiv2 && go build -o /out/usr/bin/protoc-gen-openapiv2 main.go
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,6 @@ docker run --rm -v $(pwd):/go/src/${project} \
 
 - protoc-gen-go
 - protoc-gen-go-grpc
-- protoc-gen-combo
-- protoc-gen-gofast
-- protoc-gen-gogo
-- protoc-gen-gogofast
-- protoc-gen-gogofaster
-- protoc-gen-gogoslick
-- protoc-gen-gogotypes
-- protoc-gen-gostring
 - protoc-gen-openapiv2 (**Infoblox Open with atlas-patch**)
 - protoc-gen-grpc-gateway (**Infoblox Open**)
 - protoc-gen-doc


### PR DESCRIPTION
[B-56160](https://www10.v1host.com/InfobloxNewV1/story.mvc/Summary?oidToken=Story%3a489420) Replace protoc-gen-swagger with protoc-gen-openapiv2

[B-51119](https://www10.v1host.com/InfobloxNewV1/story.mvc/Summary?oidToken=Story%3A431411&RoomContext=TeamRoom%3A7327&concept=TeamRoom) Stretch: Migrate tagging to protoc-gen-openapiv2

Changes are tested on included test.proto file.