### PR TITLE
v20 - preprocess: use git tag v1.0.1

### DIFF
--- a/plugin.version
+++ b/plugin.version
@@ -2,4 +2,4 @@ atlas-app-toolkit=v0.19.2
 protoc-gen-gorm=v0.19.0
 protoc-gen-atlas-query-validate=v0.5.1
 protoc-gen-atlas-validate=v0.4.1
-protoc-gen-preprocess=master
+protoc-gen-preprocess=v1.0.1


### PR DESCRIPTION
updated to use a static git tag instead of head of master branch.