### PR TITLE
Upgrade atlas-patch to support response code customization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cd ${GOPATH}/src/github.com/infobloxopen && git clone --single-branch --bran
     cd ${GOPATH}/src/github.com/infobloxopen/grpc-gateway/protoc-gen-openapiv2 && go build -o /out/usr/bin/protoc-gen-openapiv2 main.go
 
 # Build with infoblox atlas_patch.
-RUN cd ${GOPATH}/src/github.com/infobloxopen && git clone --single-branch --branch v1.0.0 https://github.com/infobloxopen/atlas-openapiv2-patch.git && \
+RUN cd ${GOPATH}/src/github.com/infobloxopen && git clone --single-branch --branch v1.0.1 https://github.com/infobloxopen/atlas-openapiv2-patch.git && \
     cd ${GOPATH}/src/github.com/infobloxopen/atlas-openapiv2-patch && go mod vendor && go build -o /out/usr/bin/atlas_patch ./cmd/server/.
 
 # Copy in proto files, some are in non-go packages and are stored in third_party


### PR DESCRIPTION
atlas-gentool 21.13 is needed to support array-type response body.
We also need support for response code customization, 
which is not available in atlas-openapiv2-patch v1.0.0.

This PR is to bring atlas-openapiv2-patch v1.0.1 into the branch v21-14
to support response code customization
