### PR TITLE
Version changes related to pagination total count

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # The docker image to generate Golang code from Protol Buffer.
-FROM golang:1.18.10-alpine3.17 as builder
+FROM golang:1.21.6-alpine3.19 as builder
 LABEL intermediate=true
 MAINTAINER DL NGP-App-Infra-API <ngp-app-infra-api@infoblox.com>
 

--- a/plugin.version
+++ b/plugin.version
@@ -1,5 +1,5 @@
-atlas-app-toolkit=v0.25.4
-protoc-gen-gorm=v0.20.0
+atlas-app-toolkit=v0.25.7
+protoc-gen-gorm=v0.20.2
 protoc-gen-atlas-query-validate=v0.5.1
 protoc-gen-atlas-validate=v0.4.1
 protoc-gen-preprocess=v0.3.3


### PR DESCRIPTION
Upgraded the go version from `golang:1.18.10-alpine3.17`  to  `golang:1.21.6-alpine3.19`  as the current version has unsafe.stringdata error